### PR TITLE
Factory LogzioSender + Different buffers for different types

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This appender uses [BigQueue](https://github.com/bulldog2011/bigqueue) implement
 <dependency>
     <groupId>io.logz.logback</groupId>
     <artifactId>logzio-logback-appender</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
 </dependency>
 ```
 
@@ -91,6 +91,9 @@ Will send a log to Logz.io that looks like this:
 ```
 
 ### Release notes
+ - 1.0.7
+   - Create different buffers for different types
+   - Moved LogzioSender class to be a factory, by log type - meaning no different configurations for the same type (which does not make sense anyway)
  - 1.0.6
    - Fix: Appender can get into dead-lock thus causing all threads logging to bloc
    - Refactored all Unit tests 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.logz.logback</groupId>
     <artifactId>logzio-logback-appender</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
 
     <packaging>jar</packaging>
     <name>Logz.io Logback Appender</name>

--- a/src/main/java/io/logz/logback/LogzioLogbackAppender.java
+++ b/src/main/java/io/logz/logback/LogzioLogbackAppender.java
@@ -156,12 +156,12 @@ public class LogzioLogbackAppender extends UnsynchronizedAppenderBase<ILoggingEv
             }
         }
         else {
-            bufferDir = System.getProperty("java.io.tmpdir") + "/logzio-logback-buffer";
+            bufferDir = System.getProperty("java.io.tmpdir") + "/logzio-logback-buffer/" + logzioType;
         }
 
         try {
             StatusReporter reporter = new StatusReporter();
-            logzioSender = new LogzioSender(logzioToken, logzioType, drainTimeoutSec, fileSystemFullPercentThreshold,
+            logzioSender = LogzioSender.getOrCreateSenderByType(logzioToken, logzioType, drainTimeoutSec, fileSystemFullPercentThreshold,
                                             bufferDir, logzioUrl, socketTimeout, connectTimeout, debug,
                                             reporter, context.getScheduledExecutorService(), addHostname,
                                             additionalFields, gcPersistedQueueFilesIntervalSeconds);

--- a/src/main/java/io/logz/logback/LogzioLogbackAppender.java
+++ b/src/main/java/io/logz/logback/LogzioLogbackAppender.java
@@ -142,6 +142,8 @@ public class LogzioLogbackAppender extends UnsynchronizedAppenderBase<ILoggingEv
         }
 
         if (bufferDir != null) {
+
+            bufferDir += "/" + logzioType;
             File bufferFile = new File(bufferDir);
             if (bufferFile.exists()) {
                 if (!bufferFile.canWrite()) {

--- a/src/main/java/io/logz/logback/LogzioSender.java
+++ b/src/main/java/io/logz/logback/LogzioSender.java
@@ -31,6 +31,8 @@ public class LogzioSender {
     public static final int INITIAL_WAIT_BEFORE_RETRY_MS = 2000;
     public static final int MAX_RETRIES_ATTEMPTS = 3;
 
+    private static final Map<String, LogzioSender> logzioSenderInstances = new HashMap<>();
+
     private final BigQueue logsBuffer;
     private final File queueDirectory;
     private final URL logzioListenerUrl;
@@ -54,7 +56,7 @@ public class LogzioSender {
     private final int gcPersistedQueueFilesIntervalSeconds;
     private final AtomicBoolean drainRunning = new AtomicBoolean(false);
 
-    public LogzioSender(String logzioToken, String logzioType, int drainTimeout, int fsPercentThreshold, String bufferDir,
+    private LogzioSender(String logzioToken, String logzioType, int drainTimeout, int fsPercentThreshold, String bufferDir,
                         String logzioUrl, int socketTimeout, int connectTimeout, boolean debug,
                         LogzioLogbackAppender.StatusReporter reporter, ScheduledExecutorService tasksExecutor,
                         boolean addHostname, String additionalFields, int gcPersistedQueueFilesIntervalSeconds)
@@ -123,6 +125,26 @@ public class LogzioSender {
         throwableProxyConverter.start();
 
         debug("Created new LogzioSender class");
+    }
+
+    public static LogzioSender getOrCreateSenderByType(String logzioToken, String logzioType, int drainTimeout, int fsPercentThreshold, String bufferDir,
+                                                       String logzioUrl, int socketTimeout, int connectTimeout, boolean debug,
+                                                       LogzioLogbackAppender.StatusReporter reporter, ScheduledExecutorService tasksExecutor,
+                                                       boolean addHostname, String additionalFields, int gcPersistedQueueFilesIntervalSeconds) {
+
+        LogzioSender logzioSenderInstance = logzioSenderInstances.get(logzioType);
+
+        if (logzioSenderInstance == null) {
+
+            LogzioSender logzioSender = new LogzioSender(logzioToken, logzioType, drainTimeout, fsPercentThreshold,
+                    bufferDir, logzioUrl, socketTimeout, connectTimeout, debug, reporter,
+                    tasksExecutor, addHostname, additionalFields, gcPersistedQueueFilesIntervalSeconds);
+
+            logzioSenderInstances.put(logzioType, logzioSender);
+            return logzioSender;
+        } else {
+            return logzioSenderInstance;
+        }
     }
 
     public void start() {


### PR DESCRIPTION
PR for #14 

Different log types have different buffers, also LogzioSender is now a factory that generates logzioSenders by the type.
Effectively disables having different configurations for different types, but that does not make sense anyway.