### PR TITLE
Don't manage thread executor, logback does it by it-self + test

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Will send a log to Logz.io that looks like this:
 
 ### Release notes
  - 1.0.9
-   - Fixed an issue preventing the appender to restart if asked
+   - Fixed an issue preventing the appender to restart if asked. Also, prevented hot-loading of logback config.xml
  - 1.0.8
    - Fixed filesystem percentage wrong calculation (#12)
  - 1.0.7

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This appender uses [BigQueue](https://github.com/bulldog2011/bigqueue) implement
 <dependency>
     <groupId>io.logz.logback</groupId>
     <artifactId>logzio-logback-appender</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
 </dependency>
 ```
 
@@ -91,6 +91,8 @@ Will send a log to Logz.io that looks like this:
 ```
 
 ### Release notes
+ - 1.0.9
+   - Fixed an issue preventing the appender to restart if asked
  - 1.0.8
    - Fixed filesystem percentage wrong calculation (#12)
  - 1.0.7

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.logz.logback</groupId>
     <artifactId>logzio-logback-appender</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
 
     <packaging>jar</packaging>
     <name>Logz.io Logback Appender</name>

--- a/src/main/java/io/logz/logback/LogzioSender.java
+++ b/src/main/java/io/logz/logback/LogzioSender.java
@@ -158,20 +158,8 @@ public class LogzioSender {
     }
 
     public void stop() {
-        try {
-            debug("Submitting a final drain queue task to drain before shutdown");
-            tasksExecutor.schedule(this::drainQueue, 0, TimeUnit.SECONDS);
-            debug("Got stop request, stopping new executions");
-            tasksExecutor.shutdown();
-            debug("Waiting up to 20 seconds for tasks to finish");
-            tasksExecutor.awaitTermination(20, TimeUnit.SECONDS);
-            debug("Shutting all tasks forcefully");
-            tasksExecutor.shutdownNow();
-        } catch (InterruptedException e) {
-
-            // Reset the interrupt flag
-            Thread.currentThread().interrupt();
-        }
+        debug("Got stop request, Submitting a final drain queue task to drain before shutdown");
+        tasksExecutor.schedule(this::drainQueue, 0, TimeUnit.SECONDS);
     }
 
     public void gcBigQueue() {

--- a/src/main/java/io/logz/logback/LogzioSender.java
+++ b/src/main/java/io/logz/logback/LogzioSender.java
@@ -36,7 +36,7 @@ public class LogzioSender {
     public static final int MAX_RETRIES_ATTEMPTS = 3;
 
     private static final Map<String, LogzioSender> logzioSenderInstances = new HashMap<>();
-    public static final int FINAL_DRAIN_TIMEOUT_SEC = 20;
+    private static final int FINAL_DRAIN_TIMEOUT_SEC = 20;
 
     private final BigQueue logsBuffer;
     private final File queueDirectory;
@@ -165,12 +165,12 @@ public class LogzioSender {
     public void stop() {
         // Creating a scheduled executor, outside of logback to try and drain the queue one last time
         ExecutorService executorService = Executors.newSingleThreadExecutor();
-        debug("Got stop request, Submitting a final drain queue task to drain before shutdown");
+        debug("Got stop request, Submitting a final drain queue task to drain before shutdown. Will timeout in " + FINAL_DRAIN_TIMEOUT_SEC + " seconds.");
 
         try {
             executorService.submit(this::drainQueue).get(FINAL_DRAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            debug("Waited " + FINAL_DRAIN_TIMEOUT_SEC + " seconds, but could not finish draining. quitting.");
+            debug("Waited " + FINAL_DRAIN_TIMEOUT_SEC + " seconds, but could not finish draining. quitting.", e);
         } finally {
             executorService.shutdownNow();
         }

--- a/src/main/java/io/logz/logback/LogzioSender.java
+++ b/src/main/java/io/logz/logback/LogzioSender.java
@@ -22,8 +22,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class LogzioSender {
@@ -32,6 +36,7 @@ public class LogzioSender {
     public static final int MAX_RETRIES_ATTEMPTS = 3;
 
     private static final Map<String, LogzioSender> logzioSenderInstances = new HashMap<>();
+    public static final int FINAL_DRAIN_TIMEOUT_SEC = 20;
 
     private final BigQueue logsBuffer;
     private final File queueDirectory;
@@ -158,8 +163,17 @@ public class LogzioSender {
     }
 
     public void stop() {
+        // Creating a scheduled executor, outside of logback to try and drain the queue one last time
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
         debug("Got stop request, Submitting a final drain queue task to drain before shutdown");
-        tasksExecutor.schedule(this::drainQueue, 0, TimeUnit.SECONDS);
+
+        try {
+            executorService.submit(this::drainQueue).get(FINAL_DRAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            debug("Waited " + FINAL_DRAIN_TIMEOUT_SEC + " seconds, but could not finish draining. quitting.");
+        } finally {
+            executorService.shutdownNow();
+        }
     }
 
     public void gcBigQueue() {

--- a/src/test/java/io/logz/LogzioSenderTest.java
+++ b/src/test/java/io/logz/LogzioSenderTest.java
@@ -381,6 +381,7 @@ public class LogzioSenderTest extends BaseTest {
         assertThat(logRequest.getStringFieldOrNull(mdcKey)).isEqualTo(mdcValue);
     }
 
+    //context.reset() is called when logback loads a new logback.xml in-flight
     @Test
     public void testContextReset() throws Exception {
 


### PR DESCRIPTION
Fixed #17.

Removed the executor shutdown.

Made a test before to confirm its failing, and then fixed.