### PR TITLE
retrieve $ENV_VAR_NAME from env properties if not available in env variables

### DIFF
--- a/src/test/java/io/logz/logback/ExceptionLogbackAppenderTest.java
+++ b/src/test/java/io/logz/logback/ExceptionLogbackAppenderTest.java
@@ -36,7 +36,7 @@ public class ExceptionLogbackAppenderTest extends BaseLogbackAppenderTest {
         String expectedException = "java.lang.RuntimeException: Got NPE!\n" +
                 "\tat io.logz.logback.MyRunner$ExceptionGenerator.generateNPE(MyRunner.java:33)\n" +
                 "\tat io.logz.logback.MyRunner.run(MyRunner.java:18)\n" +
-                "\tat java.lang.Thread.run(Thread.java:745)\n" +
+                "\tat java.lang.Thread.run(Thread.java:748)\n" +
                 "Caused by: java.lang.NullPointerException: null\n" +
                 "\tat io.logz.logback.MyRunner$ExceptionGenerator.generateNPE(MyRunner.java:31)\n" +
                 "\t... 2 common frames omitted\n";


### PR DESCRIPTION
I would need this feature in order to access the env properties set in my Amazon elastic beanstalk instances, these are unfortunately set as properties and not variables.