### PR TITLE
Added support for JSON parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This appender uses [LogzioSender](https://github.com/logzio/logzio-java-sender) 
 | **debug**       | *false*                                    | Print some debug messages to stdout to help to diagnose issues |
 | **line**       | *false*                                    | Print the line of code that generated this log  |
 | **compressRequests**       | *false*                                    | Boolean. `true` if logs are compressed in gzip format before sending. `false` if logs are sent uncompressed. |
-
+| **format** | *text*  | Optional. `json` if the logged message is to be parsed as a JSON (in such a way that each JSON node will be a field in logz.io) or `text` if the logged message is to be treated as plain text.
 
 ### Code Example
 ```java

--- a/pom.xml
+++ b/pom.xml
@@ -2,11 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <distributionManagement>
+        <snapshotRepository>
+            <id>nexus-snapshots</id>
+            <url>http://52.42.56.111:8081/nexus/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.logz.logback</groupId>
     <artifactId>logzio-logback-appender</artifactId>
-    <version>0-SNAPSHOT</version>
+    <version>1-CLARIZEN-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Logz.io Logback Appender</name>
@@ -72,20 +78,6 @@
                         <id>attach-javadocs</id>
                         <goals>
                             <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -2,17 +2,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <distributionManagement>
-        <snapshotRepository>
-            <id>nexus-snapshots</id>
-            <url>http://52.42.56.111:8081/nexus/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.logz.logback</groupId>
     <artifactId>logzio-logback-appender</artifactId>
-    <version>1-CLARIZEN-SNAPSHOT</version>
+    <version>0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Logz.io Logback Appender</name>
@@ -78,6 +72,20 @@
                         <id>attach-javadocs</id>
                         <goals>
                             <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/java/io/logz/logback/LogzioLogbackAppender.java
+++ b/src/main/java/io/logz/logback/LogzioLogbackAppender.java
@@ -229,7 +229,7 @@ public class LogzioLogbackAppender extends UnsynchronizedAppenderBase<ILoggingEv
             JsonElement jsonElement = gson.fromJson(loggingEvent.getFormattedMessage(), JsonElement.class);
 
             logMessage = jsonElement.getAsJsonObject();
-        } catch (JsonSyntaxException | IllegalStateException e) {
+        } catch (Exception e) {
             logMessage = new JsonObject();
             logMessage.addProperty(MESSAGE, loggingEvent.getFormattedMessage());
         }

--- a/src/main/java/io/logz/logback/LogzioLogbackAppender.java
+++ b/src/main/java/io/logz/logback/LogzioLogbackAppender.java
@@ -15,7 +15,12 @@ import io.logz.sender.exceptions.LogzioParameterErrorException;
 import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class LogzioLogbackAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 

--- a/src/main/java/io/logz/logback/LogzioLogbackAppender.java
+++ b/src/main/java/io/logz/logback/LogzioLogbackAppender.java
@@ -10,18 +10,12 @@ import io.logz.sender.SenderStatusReporter;
 import io.logz.sender.com.google.gson.Gson;
 import io.logz.sender.com.google.gson.JsonElement;
 import io.logz.sender.com.google.gson.JsonObject;
-import io.logz.sender.com.google.gson.JsonSyntaxException;
 import io.logz.sender.exceptions.LogzioParameterErrorException;
 
 import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class LogzioLogbackAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     private static final Gson gson = new Gson();

--- a/src/main/java/io/logz/logback/LogzioLogbackAppender.java
+++ b/src/main/java/io/logz/logback/LogzioLogbackAppender.java
@@ -227,7 +227,6 @@ public class LogzioLogbackAppender extends UnsynchronizedAppenderBase<ILoggingEv
 
         try {
             JsonElement jsonElement = gson.fromJson(loggingEvent.getFormattedMessage(), JsonElement.class);
-
             logMessage = jsonElement.getAsJsonObject();
         } catch (Exception e) {
             logMessage = new JsonObject();

--- a/src/test/java/io/logz/logback/BaseLogbackAppenderTest.java
+++ b/src/test/java/io/logz/logback/BaseLogbackAppenderTest.java
@@ -6,6 +6,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,6 +48,7 @@ public class BaseLogbackAppenderTest {
         logzioLogbackAppender.setLogzioUrl("http://" + mockListener.getHost() + ":" + mockListener.getPort());
         logzioLogbackAppender.setAddHostname(addHostname);
         logzioLogbackAppender.setCompressRequests(compressRequests);
+        logzioLogbackAppender.setName("LogzioLogbackAppender");
         if (drainTimeout != null) {
             logzioLogbackAppender.setDrainTimeoutSec(drainTimeout);
         }

--- a/src/test/java/io/logz/logback/LogzioLogbackAppenderTest.java
+++ b/src/test/java/io/logz/logback/LogzioLogbackAppenderTest.java
@@ -6,11 +6,7 @@ import ch.qos.logback.classic.LoggerContext;
 import io.logz.sender.com.google.gson.Gson;
 import io.logz.test.MockLogzioBulkListener;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
-import org.slf4j.Marker;
-import org.slf4j.MarkerFactory;
+import org.slf4j.*;
 
 import java.net.InetAddress;
 import java.util.HashMap;
@@ -40,6 +36,9 @@ public class LogzioLogbackAppenderTest extends BaseLogbackAppenderTest {
         String message1 = new Gson().toJson(map);
 
         Logger testLogger = createLogger(token, type, loggerName, drainTimeout, false, false, null);
+        LogzioLogbackAppender logzioLogbackAppender =
+                (LogzioLogbackAppender)((ch.qos.logback.classic.Logger)testLogger).getAppender("LogzioLogbackAppender");
+        logzioLogbackAppender.setFormat("json");
         testLogger.info(message1);
 
         sleepSeconds(2 * drainTimeout);

--- a/src/test/java/io/logz/logback/LogzioLogbackAppenderTest.java
+++ b/src/test/java/io/logz/logback/LogzioLogbackAppenderTest.java
@@ -48,7 +48,7 @@ public class LogzioLogbackAppenderTest extends BaseLogbackAppenderTest {
         String token = "aBcDeFgHiJkLmNoPqRsTGzIp";
         String type = "awesomeGzipType";
         String loggerName = "simpleGzipAppending";
-        int drainTimeout = 1;
+        int drainTimeout = 5;
         String message1 = "Testing.." + random(5);
         String message2 = "Warning test.." + random(5);
 

--- a/src/test/java/io/logz/logback/LogzioLogbackAppenderTest.java
+++ b/src/test/java/io/logz/logback/LogzioLogbackAppenderTest.java
@@ -25,6 +25,34 @@ public class LogzioLogbackAppenderTest extends BaseLogbackAppenderTest {
     private final static Logger logger = LoggerFactory.getLogger(LogzioLogbackAppenderTest.class);
 
     @Test
+    public void validateJsonMessage(){
+        String token = "validatingAdditionalFields";
+        String type = "willTryWithOrWithoutEnvironmentVariables";
+        String loggerName = "additionalLogger";
+        int drainTimeout = 1;
+        String messageText = "message test";
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("message", messageText);
+        map.put("userName", "test");
+        map.put("email", "test@email.com");
+
+        String message1 = new Gson().toJson(map);
+
+        Logger testLogger = createLogger(token, type, loggerName, drainTimeout, false, false, null);
+        testLogger.info(message1);
+
+        sleepSeconds(2 * drainTimeout);
+
+        mockListener.assertNumberOfReceivedMsgs(1);
+        MockLogzioBulkListener.LogRequest logRequest = mockListener.assertLogReceivedByMessage(messageText);
+        mockListener.assertLogReceivedIs(logRequest, token, type, loggerName, Level.INFO.levelStr);
+
+        assertThat(logRequest.getStringFieldOrNull("userName")).isNotNull().isEqualTo("test");
+        assertThat(logRequest.getStringFieldOrNull("email")).isNotNull().isEqualTo("test@email.com");
+    }
+
+    @Test
     public void simpleAppending() throws Exception {
         String token = "aBcDeFgHiJkLmNoPqRsT";
         String type = "awesomeType";
@@ -264,34 +292,6 @@ public class LogzioLogbackAppenderTest extends BaseLogbackAppenderTest {
         mockListener.assertNumberOfReceivedMsgs(1);
         MockLogzioBulkListener.LogRequest logRequest = mockListener.assertLogReceivedByMessage(message1);
         mockListener.assertLogReceivedIs(logRequest, token, type, loggerName, Level.INFO.levelStr);
-    }
-
-    @Test
-    public void validateJsonMessage(){
-        String token = "validatingAdditionalFields";
-        String type = "willTryWithOrWithoutEnvironmentVariables";
-        String loggerName = "additionalLogger";
-        int drainTimeout = 1;
-        String messageText = "message test";
-
-        Map<String, Object> map = new HashMap<>();
-        map.put("message", messageText);
-        map.put("userName", "test");
-        map.put("email", "test@email.com");
-
-        String message1 = new Gson().toJson(map);
-
-        Logger testLogger = createLogger(token, type, loggerName, drainTimeout, false, false, null);
-        testLogger.info(message1);
-
-        sleepSeconds(2 * drainTimeout);
-
-        mockListener.assertNumberOfReceivedMsgs(1);
-        MockLogzioBulkListener.LogRequest logRequest = mockListener.assertLogReceivedByMessage(messageText);
-        mockListener.assertLogReceivedIs(logRequest, token, type, loggerName, Level.INFO.levelStr);
-
-        assertThat(logRequest.getStringFieldOrNull("userName")).isNotNull().isEqualTo("test");
-        assertThat(logRequest.getStringFieldOrNull("email")).isNotNull().isEqualTo("test@email.com");
     }
 
     public void assertAdditionalFields(MockLogzioBulkListener.LogRequest logRequest, Map<String, String> additionalFields) {


### PR DESCRIPTION
Hi,
At the company I work for we have many custom fields in our logs.
And some of our custom fields have dynamic values. for example, we have a custom field called _userName_ which contains the user that triggered the method.
In order to deal with this kind of custom fields, we wanted to send the logs in a JSON format and let the appender handle the parsing.
So In the formatMessageAsJson function, I convert the message to a JsonElement using Gson. 
All the tests still pass after my change, and in addition, I have added a new test (validateJsonMessage) to check logging a custom field using JSON formatting.
I believe this change may help other users as well. Please consider pulling this changes.
Thanks.