### PR TITLE
Remove SLF4j from uber-jar file, but keep it in dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,11 +145,6 @@
             <version>${logzio-sender-version}</version>
             <exclusions>
                 <exclusion>
-                    <!--
-                        Exclude SLF4j here because this dependency already included in logback-classic with "provided" scope.
-                        If this dependency appears in "runtime" scope it will be put in an uber-jar by the maven-shade-plugin
-                        and causes a clash with classes from the original SLF4j library (probably with a different version).
-                    -->
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,17 @@
             <groupId>io.logz.sender</groupId>
             <artifactId>logzio-sender</artifactId>
             <version>${logzio-sender-version}</version>
+            <exclusions>
+                <exclusion>
+                    <!--
+                        Exclude SLF4j here because this dependency already included in logback-classic with "provided" scope.
+                        If this dependency appears in "runtime" scope it will be put in an uber-jar by the maven-shade-plugin
+                        and causes a clash with classes from the original SLF4j library (probably with a different version).
+                    -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
SLF4j from logzio-appender clashes with the original library which has different version. This change fix it.

Here is example of this problem with logs: https://github.com/logzio/logzio-logback-appender/issues/20#issuecomment-357711853.