### PR TITLE
Correct shading, so there is a single remaining dependency: logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -115,15 +115,25 @@
                 </executions>
                 <configuration>
                     <minimizeJar>true</minimizeJar>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <artifactSet>
+                        <includes>
+                            <include>*:*</include>
+                        </includes>
+                        <excludes>
+                            <exclude>ch.qos.logback:*</exclude>
+                            <exclude>org.slf4j:*</exclude>
+                        </excludes>
+                    </artifactSet>
                     <relocations>
                         <relocation>
-                            <pattern>com.google</pattern>
-                            <shadedPattern>io.logz.logback.com.google</shadedPattern>
-                        </relocation>
-                        <relocation>
-                            <pattern>io.logz.sender</pattern>
-                            <shadedPattern>io.logz.logback-appender.sender</shadedPattern>
+                            <pattern></pattern>
+                            <!-- shade everything to the same dir as sender, to avoid duplicate classes -->
+                            <shadedPattern>io.logz.sender.</shadedPattern>
+                            <excludes>
+                                <exclude>%regex[^io.logz.*]</exclude>
+                                <exclude>%regex[^META-INF/.*]</exclude>
+                            </excludes>
                         </relocation>
                     </relocations>
                     <filters>
@@ -136,6 +146,24 @@
                     </filters>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.2.7</version>
+                <configuration>
+                    <flattenMode>clean</flattenMode>
+                    <updatePomFile>true</updatePomFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>
@@ -143,18 +171,11 @@
             <groupId>io.logz.sender</groupId>
             <artifactId>logzio-sender</artifactId>
             <version>${logzio-sender-version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
We had issues with duplicate classes, since the shading is not correct and the shaded dependencies were not removed from the published pom.xml.

With the changes this produces an artifact without having the risk of duplicate classes and the reduced pom.xml will look like this.
```
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>io.logz.logback</groupId>
  <artifactId>logzio-logback-appender</artifactId>
  <version>0-SNAPSHOT</version>
  <licenses>
    <license>
      <name>The Apache License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
    </license>
  </licenses>
  <dependencies>
    <dependency>
      <groupId>ch.qos.logback</groupId>
      <artifactId>logback-classic</artifactId>
      <version>1.2.3</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
</project>


```